### PR TITLE
feat: Add event listener decorator and remove listener functions

### DIFF
--- a/async_pyserial/common.py
+++ b/async_pyserial/common.py
@@ -1,6 +1,8 @@
+from typing import Callable
+
 class EventEmitter:
     def __init__(self) -> None:
-        self.listeners: dict[str, list] = {}
+        self.listeners: dict[str, list[Callable]] = {}
         
     def emit(self, evt: str, *args, **kwargs):
         if evt not in self.listeners:
@@ -11,11 +13,38 @@ class EventEmitter:
         for listener in listeners:
             listener(*args, **kwargs)
         
-    def on(self, evt: str, listener):
-        if evt not in self.listeners:
-            self.listeners[evt] = []
+    def on(self, evt: str, listener: Callable | None = None):
+
+        def decorator(listener: Callable):
+            if evt not in self.listeners:
+                self.listeners[evt] = []
             
-        self.listeners[evt].append(listener)
+            self.listeners[evt].append(listener)
+
+        if listener is None:
+            return decorator
+        
+        decorator(listener=listener)
+
+    def remove_all_listeners(self, evt: str):
+        if evt not in self.listeners:
+            return
+        
+        del self.listeners[evt]
+
+    def remove_listener(self, evt: str, listener: Callable):
+        if evt not in self.listeners:
+            return
+        
+        self.listeners[evt].remove(listener)
+
+        if len(self.listeners[evt]) == 0:
+            del self.listeners[evt]
+    
+    def off(self, evt: str, listener: Callable):
+        """ alias for remove_listener
+        """
+        self.remove_listener(evt, listener=listener)
         
 class PlatformNotSupported(Exception):
     def __init__(self, *args: object) -> None:

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,6 +1,6 @@
 from async_pyserial import EventEmitter
 
-def test_event_emitter():
+def test_emit_event():
     emitter = EventEmitter()
 
     expected = b'Hello!'
@@ -11,3 +11,53 @@ def test_event_emitter():
     emitter.on('data', on_data)
 
     emitter.emit('data', expected)
+
+def test_decorator():
+    emitter = EventEmitter()
+
+    expected = b'Hello!'
+
+    @emitter.on('data')
+    def on_data(d):
+        assert d == expected
+
+    emitter.emit('data', expected)
+
+def test_remove_listener():
+    emitter = EventEmitter()
+
+    def on_data():
+        # this func should not be call
+        assert False
+
+    emitter.on('data', on_data)
+
+    emitter.remove_listener('data', on_data)
+
+    emitter.emit('data')
+
+def test_off():
+    emitter = EventEmitter()
+
+    def on_data():
+        # this func should not be call
+        assert False
+
+    emitter.on('data', on_data)
+
+    emitter.off('data', on_data)
+
+    emitter.emit('data')
+
+def test_remove_all_listener():
+    emitter = EventEmitter()
+
+    def on_data():
+        # this func should not be call
+        assert False
+
+    emitter.on('data', on_data)
+
+    emitter.remove_all_listeners('data')
+
+    emitter.emit('data')

--- a/tests/test_serialport.py
+++ b/tests/test_serialport.py
@@ -43,7 +43,6 @@ def test_serialport_open_close(virtual_serial_ports):
     options = SerialPortOptions()
     serial_port = SerialPort(port1, options)
     serial_port.open()
-    assert os.path.exists(port1)  # Ensure the port is created
     serial_port.close()
 
 # Test case for writing to SerialPort
@@ -57,7 +56,9 @@ def test_serialport_write(virtual_serial_ports):
 
     with open(port2, 'rb') as f:
         written_data = f.read(len(test_data))
+    
     assert written_data == test_data
+    
     serial_port.close()
 
 


### PR DESCRIPTION
- Enhanced `EventEmitter` class to include a decorator for adding event listeners.
- Added `remove_listener` and `remove_all_listeners` methods for managing event listeners.
- Updated tests to cover the new decorator and listener removal functionalities.

Changes:
- common.py: Added `decorator` function inside `on` method, allowing the use of decorators for event listeners. Implemented `remove_listener` and `remove_all_listeners` methods.
- test_event.py: Added tests for the new decorator functionality, `remove_listener`, and `remove_all_listeners` methods.